### PR TITLE
Feature/streaming chat

### DIFF
--- a/src/components/LlmChat/ChatView.tsx
+++ b/src/components/LlmChat/ChatView.tsx
@@ -76,7 +76,7 @@ const ChatViewComponent = React.forwardRef<ChatViewRef>((props, ref) => {
     if (!chatContainerRef.current) return;
     const container = chatContainerRef.current;
     container.scrollTop = container.scrollHeight;
-  }, []); 
+  }, []);
 
   // Handle message updates
   useEffect(() => {
@@ -340,7 +340,9 @@ const ChatViewComponent = React.forwardRef<ChatViewRef>((props, ref) => {
 
         // Handle tool use in the final response if any
         const finalResponse = await stream.finalMessage();
-        
+        currentMessages.push(finalResponse);
+        updateConversationMessages(activeProject.id, activeConversationId, currentMessages);
+
         // If this is a new conversation, generate a title
         if (activeConversation && cachedApiMessages.length === 2) {
           const userFirstMessage = cachedApiMessages[0].content;


### PR DESCRIPTION
resolves #7

cc50c11 was written with the following prompt; af6ef4a was written by hand by a genuine human

# System prompt

You are a software engineer who strategically uses tools.

Address issues in order by understanding the code in the repo at `/home/nick/llm-chat` and then making required edits to the code. After editing you should lint using `npm run lint` and fix any linter errors and then build using `npm run build` and fix any compiler errors. Finally, create a new branch with a descriptive name and well-scoped commits with descriptive messages. You should solve each issue sequentially and each issue should get its own commit.

# First message

## Basic message docs

### Request

```
import { Anthropic } from '@anthropic-ai/sdk';

const anthropic = new Anthropic();

await anthropic.messages.create({
  model: "claude-3-5-sonnet-20241022",
  max_tokens: 1024,
  messages: [
    {"role": "user", "content": "Hello, world"}
  ]
});
```

### Response

```
{
  "content": [
    {
      "text": "Hi! My name is Claude.",
      "type": "text"
    }
  ],
  "id": "msg_013Zva2CMHLNnXjNJJKqJ2EF",
  "model": "claude-3-5-sonnet-20241022",
  "role": "assistant",
  "stop_reason": "end_turn",
  "stop_sequence": null,
  "type": "message",
  "usage": {
    "input_tokens": 2095,
    "output_tokens": 503
  }
}
```

## Streaming message docs

### Usage example
```
import Anthropic from '@anthropic-ai/sdk';

const client = new Anthropic();

await client.messages.stream({
    messages: [{role: 'user', content: "Hello"}],
    model: 'claude-3-5-sonnet-20241022',
    max_tokens: 1024,
}).on('text', (text) => {
    console.log(text);
});

```

### Discussion

Event types
Each server-sent event includes a named event type and associated JSON data. Each event will use an SSE event name (e.g. event: message_stop), and include the matching event type in its data.

Each stream uses the following event flow:

message_start: contains a Message object with empty content.
A series of content blocks, each of which have a content_block_start, one or more content_block_delta events, and a content_block_stop event. Each content block will have an index that corresponds to its index in the final Message content array.
One or more message_delta events, indicating top-level changes to the final Message object.
A final message_stop event.
​
Ping events
Event streams may also include any number of ping events.

​
Error events
We may occasionally send errors in the event stream. For example, during periods of high usage, you may receive an overloaded_error, which would normally correspond to an HTTP 529 in a non-streaming context:

Example error

event: error
data: {"type": "error", "error": {"type": "overloaded_error", "message": "Overloaded"}}
​
Other events
In accordance with our versioning policy, we may add new event types, and your code should handle unknown event types gracefully.

​
Delta types
Each content_block_delta event contains a delta of a type that updates the content block at a given index.

​
Text delta
A text content block delta looks like:

Text delta

event: content_block_delta
data: {"type": "content_block_delta","index": 0,"delta": {"type": "text_delta", "text": "ello frien"}}
​
Input JSON delta
The deltas for tool_use content blocks correspond to updates for the input field of the block. To support maximum granularity, the deltas are partial JSON strings, whereas the final tool_use.input is always an object.

You can accumulate the string deltas and parse the JSON once you receive a content_block_stop event, by using a library like Pydantic to do partial JSON parsing, or by using our SDKs, which provide helpers to access parsed incremental values.

A tool_use content block delta looks like:

Input JSON delta

event: content_block_delta
data: {"type": "content_block_delta","index": 1,"delta": {"type": "input_json_delta","partial_json": "{\"location\": \"San Fra"}}}
Note: Our current models only support emitting one complete key and value property from input at a time. As such, when using tools, there may be delays between streaming events while the model is working. Once an input key and value are accumulated, we emit them as multiple content_block_delta events with chunked partial json so that the format can automatically support finer granularity in future models.

## Issue

[feature] stream chat updates from anthropic (rather than just getting entire output when POST is done) #7

Change our API usage from standard messaging to streaming. This will involve:
1. Understand the differences in the methods provided from the SDK
2. Change how we update our conversation and message state
3. Properly handle incoming deltas from the API
4. Ensure the streaming updates are displayed as they come in