### PR TITLE
feat: add image and document upload support with drag-and-drop and file picker, including file type validation and preview rendering

### DIFF
--- a/src/components/LlmChat/ChatView.tsx
+++ b/src/components/LlmChat/ChatView.tsx
@@ -160,9 +160,9 @@ const ChatViewComponent = React.forwardRef<ChatViewRef>((props, ref) => {
     setError(null);
 
     try {
-      const userMessageContent: MessageContent[] = [
-        ...currentFileContent,
-      ];
+      const userMessageContent: MessageContent[] = currentFileContent.map(c =>
+        c.type === 'image' ? { ...c, fileName: undefined } : { ...c, fileName: undefined }
+      );
 
       if (inputMessage.trim()) {
         userMessageContent.push({
@@ -545,7 +545,7 @@ const ChatViewComponent = React.forwardRef<ChatViewRef>((props, ref) => {
                     : 'bg-muted text-foreground'
                 }`}
               >
-                <Image 
+                <Image
                   src={`data:${content.source.media_type};base64,${content.source.data}`}
                   alt="User uploaded image"
                   className="max-w-full h-auto rounded"
@@ -704,10 +704,10 @@ const ChatViewComponent = React.forwardRef<ChatViewRef>((props, ref) => {
         )}
         <div className="flex gap-2">
           <div className="flex items-end">
-            <FileUpload 
+            <FileUpload
               onFileSelect={(content) => {
                 setCurrentFileContent(prev => [...prev, { ...content }]);
-              }} 
+              }}
             />
           </div>
           <Textarea

--- a/src/components/LlmChat/ChatView.tsx
+++ b/src/components/LlmChat/ChatView.tsx
@@ -2,14 +2,14 @@ import React, { useEffect, useState, useRef, useCallback, useImperativeHandle } 
 import Image from 'next/image';
 import { Anthropic } from '@anthropic-ai/sdk';
 import { Tool, CacheControlEphemeral, TextBlockParam } from '@anthropic-ai/sdk/resources/messages/messages';
-import { Send, Square } from 'lucide-react';
+import { Send, Square, X } from 'lucide-react';
 import { FileUpload } from './FileUpload';
 import { Button } from '@/components/ui/button';
 import { CopyButton } from '@/components/ui/copy';
 import { Textarea } from '@/components/ui/textarea';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
-import { Message, MessageContent } from './types';
+import { Message, MessageContent, ImageMessageContent, DocumentMessageContent } from './types';
 import { Spinner } from '@/components/ui/spinner';
 import { ToolCallModal } from './ToolCallModal';
 import { useProjects } from './context/ProjectContext';
@@ -681,7 +681,28 @@ const ChatViewComponent = React.forwardRef<ChatViewRef>((props, ref) => {
         </div>
       )}
 
-      <div className="flex gap-2 p-2 bg-background fixed bottom-0 left-0 right-0 z-50 md:left-[280px] md:w-[calc(100%-280px)]">
+      <div className="flex flex-col gap-2 p-2 bg-background fixed bottom-0 left-0 right-0 z-50 md:left-[280px] md:w-[calc(100%-280px)]">
+        {currentFileContent.length > 0 && (
+          <div className="flex flex-wrap gap-2">
+            {currentFileContent.map((content, index) => (
+              <div key={index} className="flex items-center gap-2 bg-muted rounded px-2 py-1">
+                <span className="text-sm">
+                  {content.type === 'text' ? 'Text file' :
+                   ((content as ImageMessageContent | DocumentMessageContent).fileName || 'Untitled')}
+                </span>
+                <button
+                  onClick={() => {
+                    setCurrentFileContent(prev => prev.filter((_, i) => i !== index));
+                  }}
+                  className="hover:text-destructive"
+                >
+                  <X className="h-4 w-4" />
+                </button>
+              </div>
+            ))}
+          </div>
+        )}
+        <div className="flex gap-2">
           <div className="flex items-end">
             <FileUpload 
               onFileSelect={(content) => {
@@ -690,31 +711,32 @@ const ChatViewComponent = React.forwardRef<ChatViewRef>((props, ref) => {
             />
           </div>
           <Textarea
-          value={inputMessage}
-          onChange={(e) => setInputMessage(e.target.value)}
-          placeholder="Type your message"
-          onKeyDown={(e) => {
-            if (e.key === 'Enter' && !e.shiftKey && !isLoading) {
-              e.preventDefault();
-              handleSendMessage();
-            }
-          }}
+            value={inputMessage}
+            onChange={(e) => setInputMessage(e.target.value)}
+            placeholder="Type your message"
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' && !e.shiftKey && !isLoading) {
+                e.preventDefault();
+                handleSendMessage();
+              }
+            }}
             ref={inputRef}
             className="flex-1"
-          maxRows={8}
-          disabled={isLoading}
-        />
-        <Button
-          onClick={isLoading ? cancelCurrentCall : handleSendMessage}
-          disabled={!activeProjectId || !activeConversationId}
-          className="self-end relative"
-        >
-          {isLoading ? (
-            <Square className="w-4 h-4" />
-          ) : (
-            <Send className="w-4 h-4" />
-          )}
-        </Button>
+            maxRows={8}
+            disabled={isLoading}
+          />
+          <Button
+            onClick={isLoading ? cancelCurrentCall : handleSendMessage}
+            disabled={!activeProjectId || !activeConversationId}
+            className="self-end relative"
+          >
+            {isLoading ? (
+              <Square className="w-4 h-4" />
+            ) : (
+              <Send className="w-4 h-4" />
+            )}
+          </Button>
+        </div>
       </div>
 
       {selectedToolCall && (

--- a/src/components/LlmChat/FileUpload/index.tsx
+++ b/src/components/LlmChat/FileUpload/index.tsx
@@ -1,13 +1,13 @@
 import React, { useRef, useCallback } from 'react';
 import { UploadCloud } from 'lucide-react';
 import { Button } from '@/components/ui/button';
-import { ImageMessageContent, DocumentMessageContent } from '../types';
+import { MessageContent } from '../types';
 
 const ACCEPTED_IMAGE_TYPES = ['image/jpeg', 'image/png', 'image/gif', 'image/webp'];
-const ACCEPTED_DOCUMENT_TYPES = ['application/pdf'];
+const ACCEPTED_DOCUMENT_TYPES = ['application/pdf', 'text/plain'];
 
 interface FileUploadProps {
-  onFileSelect: (content: ImageMessageContent | DocumentMessageContent) => void;
+  onFileSelect: (content: MessageContent) => void;
 }
 
 export const FileUpload: React.FC<FileUploadProps> = ({ onFileSelect }) => {
@@ -21,8 +21,16 @@ export const FileUpload: React.FC<FileUploadProps> = ({ onFileSelect }) => {
 
     const reader = new FileReader();
     reader.onload = async () => {
+      if (file.type === 'text/plain') {
+        const text = reader.result as string;
+        onFileSelect({
+          type: 'text',
+          text: text,
+        });
+        return;
+      }
+
       const base64Data = (reader.result as string).split(',')[1];
-      
       if (ACCEPTED_IMAGE_TYPES.includes(file.type)) {
         onFileSelect({
           type: 'image',
@@ -31,8 +39,9 @@ export const FileUpload: React.FC<FileUploadProps> = ({ onFileSelect }) => {
             media_type: file.type as 'image/jpeg' | 'image/png' | 'image/gif' | 'image/webp',
             data: base64Data,
           },
+          fileName: file.name,
         });
-      } else if (ACCEPTED_DOCUMENT_TYPES.includes(file.type)) {
+      } else if (file.type === 'application/pdf') {
         onFileSelect({
           type: 'document',
           source: {
@@ -40,6 +49,7 @@ export const FileUpload: React.FC<FileUploadProps> = ({ onFileSelect }) => {
             media_type: 'application/pdf',
             data: base64Data,
           },
+          fileName: file.name,
         });
       }
     };

--- a/src/components/LlmChat/FileUpload/index.tsx
+++ b/src/components/LlmChat/FileUpload/index.tsx
@@ -1,0 +1,103 @@
+import React, { useRef, useCallback } from 'react';
+import { UploadCloud } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { ImageMessageContent, DocumentMessageContent } from '../types';
+
+const ACCEPTED_IMAGE_TYPES = ['image/jpeg', 'image/png', 'image/gif', 'image/webp'];
+const ACCEPTED_DOCUMENT_TYPES = ['application/pdf'];
+
+interface FileUploadProps {
+  onFileSelect: (content: ImageMessageContent | DocumentMessageContent) => void;
+}
+
+export const FileUpload: React.FC<FileUploadProps> = ({ onFileSelect }) => {
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const processFile = useCallback(async (file: File) => {
+    if (!ACCEPTED_IMAGE_TYPES.includes(file.type) && !ACCEPTED_DOCUMENT_TYPES.includes(file.type)) {
+      alert('Unsupported file type. Please upload an image (JPEG, PNG, GIF, WebP) or a PDF document.');
+      return;
+    }
+
+    const reader = new FileReader();
+    reader.onload = async () => {
+      const base64Data = (reader.result as string).split(',')[1];
+      
+      if (ACCEPTED_IMAGE_TYPES.includes(file.type)) {
+        onFileSelect({
+          type: 'image',
+          source: {
+            type: 'base64',
+            media_type: file.type as 'image/jpeg' | 'image/png' | 'image/gif' | 'image/webp',
+            data: base64Data,
+          },
+        });
+      } else if (ACCEPTED_DOCUMENT_TYPES.includes(file.type)) {
+        onFileSelect({
+          type: 'document',
+          source: {
+            type: 'base64',
+            media_type: 'application/pdf',
+            data: base64Data,
+          },
+        });
+      }
+    };
+    reader.readAsDataURL(file);
+  }, [onFileSelect]);
+
+  const handleFileDrop = useCallback(
+    async (e: React.DragEvent<HTMLDivElement>) => {
+      e.preventDefault();
+      const file = e.dataTransfer.files[0];
+      if (file) {
+        await processFile(file);
+      }
+    },
+    [processFile]
+  );
+
+  const handleFileSelect = useCallback(
+    async (e: React.ChangeEvent<HTMLInputElement>) => {
+      const file = e.target.files?.[0];
+      if (file) {
+        await processFile(file);
+      }
+    },
+    [processFile]
+  );
+
+
+  const handleDragOver = (e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+  };
+
+  const triggerFileInput = () => {
+    fileInputRef.current?.click();
+  };
+
+  return (
+    <div
+      onDrop={handleFileDrop}
+      onDragOver={handleDragOver}
+      className="relative"
+    >
+      <input
+        type="file"
+        ref={fileInputRef}
+        onChange={handleFileSelect}
+        accept={[...ACCEPTED_IMAGE_TYPES, ...ACCEPTED_DOCUMENT_TYPES].join(',')}
+        className="hidden"
+      />
+      <Button
+        onClick={triggerFileInput}
+        variant="ghost"
+        size="icon"
+        className="h-8 w-8"
+        title="Upload file (Image or PDF)"
+      >
+        <UploadCloud className="h-5 w-5" />
+      </Button>
+    </div>
+  );
+};

--- a/src/components/LlmChat/types.ts
+++ b/src/components/LlmChat/types.ts
@@ -1,6 +1,26 @@
 import { McpServer } from './types/mcp';
 import { Tool, CacheControlEphemeral } from '@anthropic-ai/sdk/resources/messages/messages';
 
+export type ImageMessageContent = {
+  type: 'image';
+  source: {
+    type: 'base64';
+    media_type: 'image/jpeg' | 'image/png' | 'image/gif' | 'image/webp';
+    data: string;
+  };
+  cache_control?: CacheControlEphemeral | null;
+};
+
+export type DocumentMessageContent = {
+  type: 'document';
+  source: {
+    type: 'base64';
+    media_type: 'application/pdf';
+    data: string;
+  };
+  cache_control?: CacheControlEphemeral | null;
+};
+
 export type MessageContent = {
   type: 'text';
   text: string;
@@ -17,7 +37,7 @@ export type MessageContent = {
   content: string;
   is_error?: boolean,
   cache_control?: CacheControlEphemeral | null;
-};
+} | ImageMessageContent | DocumentMessageContent;
 
 export type Message = {
   role: 'user' | 'assistant';

--- a/src/components/LlmChat/types.ts
+++ b/src/components/LlmChat/types.ts
@@ -8,6 +8,7 @@ export type ImageMessageContent = {
     media_type: 'image/jpeg' | 'image/png' | 'image/gif' | 'image/webp';
     data: string;
   };
+  fileName?: string;
   cache_control?: CacheControlEphemeral | null;
 };
 
@@ -18,6 +19,7 @@ export type DocumentMessageContent = {
     media_type: 'application/pdf';
     data: string;
   };
+  fileName?: string;
   cache_control?: CacheControlEphemeral | null;
 };
 


### PR DESCRIPTION
resolves #37

# System prompt

You are a software engineer who strategically uses tools.

Address issues in order by understanding the code in the repo at `/home/nick/llm-chat` and then making required edits to the code. After editing you should lint using `npm run lint` and fix any linter errors and then build using `npm run build` and fix any compiler errors. Finally, create a new branch with a descriptive name and well-scoped commits with descriptive messages. You should solve each issue sequentially and each issue should get its own commit.

# First message prompt

## Vision docs

Claude can read both text and images in requests. Currently, we support the base64 source type for images, and the image/jpeg, image/png, image/gif, and image/webp media types. See our vision guide for more details.


Shell

Python

TypeScript

import Anthropic from '@anthropic-ai/sdk';

const anthropic = new Anthropic();

const image_url = "https://upload.wikimedia.org/wikipedia/commons/a/a7/Camponotus_flavomarginatus_ant.jpg"
const image_media_type = "image/jpeg"
const image_array_buffer = await ((await fetch(image_url)).arrayBuffer());
const image_data = Buffer.from(image_array_buffer).toString('base64');

const message = await anthropic.messages.create({
  model: 'claude-3-5-sonnet-20241022',
  max_tokens: 1024,
  messages: [
        {
            "role": "user",
            "content": [
                {
                    "type": "image",
                    "source": {
                        "type": "base64",
                        "media_type": image_media_type,
                        "data": image_data,
                    },
                }
            ],
        }
      ]
});
console.log(message);
JSON

{
  "id": "msg_01EcyWo6m4hyW8KHs2y2pei5",
  "type": "message",
  "role": "assistant",
  "content": [
    {
      "type": "text",
      "text": "This image shows an ant, specifically a close-up view of an ant. The ant is shown in detail, with its distinct head, antennae, and legs clearly visible. The image is focused on capturing the intricate details and features of the ant, likely taken with a macro lens to get an extreme close-up perspective."
    }
  ],
  "model": "claude-3-5-sonnet-20241022",
  "stop_reason": "end_turn",
  "stop_sequence": null,
  "usage": {
    "input_tokens": 1551,
    "output_tokens": 71
  }
}

Just as with document-query placement, Claude works best when images come before text. Images placed after text or interpolated with text will still perform well, but if your use case allows it, we recommend an image-then-text structure.

## Document (pdf) docs

PDF support
Process PDFs with Claude 3.5 Sonnet. Extract text, analyze charts, and understand visual content from your documents.

You can now ask Claude about any text, pictures, charts, and tables in PDFs you provide. Some sample use cases:

Analyzing financial reports and understanding charts/tables
Extracting key information from legal documents
Translation assistance for documents
Converting document information into structured formats
​
Before you begin
​
Check PDF requirements
Claude works with any standard PDF. However, you should ensure your request size meet these requirements when using PDF support:

Requirement	Limit
Maximum request size	32MB
Maximum pages per request	100
Format	Standard PDF (no passwords/encryption)
Please note that both limits are on the entire request payload, including any other content sent alongside PDFs.

import Anthropic from '@anthropic-ai/sdk';
import fetch from 'node-fetch';

// First fetch the file
const pdfURL = "https://assets.anthropic.com/m/1cd9d098ac3e6467/original/Claude-3-Model-Card-October-Addendum.pdf";

const pdfResponse = await fetch(pdfURL);

// Then convert the file to base64
const arrayBuffer = await pdfResponse.arrayBuffer();
const pdfBase64 = Buffer.from(arrayBuffer).toString('base64');

// Finally send the API request
const anthropic = new Anthropic();
const response = await anthropic.messages.create({
  model: 'claude-3-5-sonnet-20241022',
  max_tokens: 1024,
  messages: [
    {
      content: [
        {
          type: 'document',
          source: {
            media_type: 'application/pdf',
            type: 'base64',
            data: pdfBase64,
          },
        },
        {
          type: 'text',
          text: 'Which model has the highest human preference win rates across each use-case?',
        },
      ],
      role: 'user',
    },
  ],
});
console.log(response);

Optimize PDF processing
​
Improve performance
Follow these best practices for optimal results:

Place PDFs before text in your requests
Use standard fonts
Ensure text is clear and legible
Rotate pages to proper upright orientation
Use logical page numbers (from PDF viewer) in prompts
Split large PDFs into chunks when needed
Enable prompt caching for repeated analysis

Cache PDFs to improve performance on repeated queries:

const response = await anthropic.messages.create({
  model: 'claude-3-5-sonnet-20241022',
  max_tokens: 1024,
  messages: [
    {
      content: [
        {
          type: 'document',
          source: {
            media_type: 'application/pdf',
            type: 'base64',
            data: pdfBase64,
          },
          cache_control: { type: 'ephemeral' },
        },
        {
          type: 'text',
          text: 'Which model has the highest human preference win rates across each use-case?',
        },
      ],
      role: 'user',
    },
  ],
});
console.log(response);


## Issue

[feature] add image & document uploading

Allow users to input images and documents
1. Use the docs above to modify the code
2. Make sure it is still streaming with the `stream()` method, not synchronous with the `create()` method.
3. Correctly add any input images and documents into the existing prompt-cached input (i.e. they should be additional entries in the `content` field of the input and the last of these entries must have the `cache_control` field)
4. Accept input in two ways:
   a. A button next to the text input box that opens a file dialog box. User selects a file to include it
   b. User drags file over the webpage and drops it: include it