### PR TITLE
fix: improve user message text contrast in light mode

### DIFF
--- a/src/components/LlmChat/ChatView.tsx
+++ b/src/components/LlmChat/ChatView.tsx
@@ -496,12 +496,12 @@ const ChatViewComponent = React.forwardRef<ChatViewRef>((props, ref) => {
                 <div
                   className={`w-full rounded-lg px-4 py-2 ${
                     message.role === 'user'
-                      ? 'bg-accent text-accent-foreground'
+                      ? 'bg-accent !text-accent-foreground not-prose'
                       : 'bg-muted text-foreground'
                   }`}
                 >
                   <ReactMarkdown
-                    className="prose dark:prose-invert max-w-none"
+                    className={`prose dark:prose-invert max-w-none ${message.role === 'user' ? '[&_p]:!text-accent-foreground' : ''}`}
                     components={{
                       pre({ node, children, ...props }) {
                         return (


### PR DESCRIPTION
In the chatbox, user message text was grey in light mode. Now it is white, and shows better.